### PR TITLE
Upgrade nodejs12 → 16

### DIFF
--- a/infrastructure/stack-no-auth.template
+++ b/infrastructure/stack-no-auth.template
@@ -94,7 +94,7 @@ Resources:
           };
       Handler: index.handler
       Role: !GetAtt HelperCognitoLambdaRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 30
   HelperInitializeCognitoUser:
     Type: Custom::HelperInitCognitoFunction

--- a/infrastructure/stack-with-auth.template
+++ b/infrastructure/stack-with-auth.template
@@ -94,7 +94,7 @@ Resources:
           };
       Handler: index.handler
       Role: !GetAtt HelperCognitoLambdaRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 30
   HelperInitializeCognitoUser:
     Type: Custom::HelperInitCognitoFunction
@@ -403,7 +403,7 @@ Resources:
           };
       Handler: index.handler
       Role: !GetAtt HelperDynamoDbLambdaRole.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 30
   HelperDynamoDbInitializeDynamoDB:
     Type: Custom::InitFunction


### PR DESCRIPTION
Nodejs12 is no longer supported by AWS

Description of changes:

As AWS no longer support `nodejs12.x` this upgrades to `nodejs16.x` as documented [here](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html). We cannot go all the way to `nodejs18.x` due to an import error that occurs:

```shell
Cannot find module 'aws-sdk'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
